### PR TITLE
remove duplicated lines

### DIFF
--- a/gffread.cpp
+++ b/gffread.cpp
@@ -252,11 +252,6 @@ void setTableFormat(GStr& s) {
     	  tableCols.Add(tcol);
     	  continue;
       }
-      if (w=="geneID" || w=="gene_id") {
-    	  CTableField tcol(ctfGFF_geneID);
-    	  tableCols.Add(tcol);
-    	  continue;
-      }
       if (w=="Parent") {
     	  CTableField tcol(ctfGFF_Parent);
     	  tableCols.Add(tcol);


### PR DESCRIPTION
Thanks for the awesome tool, saved me lots of time by converting a gtf into pepides :muscle: 

I wanted to use the gene id instead of the transcript id as name of the fasta record, and decided to check the source code if that's possible (it is with `--table @geneid`, awesome :tada: ). I came across a couple duplicated lines, and took the liberty to remove them and make a PR. 